### PR TITLE
Strip whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: haskell
+env:
+  - 'UBUNTU_RELEASE=saucy GHCVER=7.8.3 CABALVER=1.20'
+
+before_install:
+  - 'sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE} main universe"'
+  - 'sudo add-apt-repository -y ppa:hvr/ghc'
+  - 'sudo apt-get update'
+  - 'sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy'
+  - 'export PATH=/opt/ghc/$GHCVER/bin:$PATH'
+  - sudo apt-get remove libzmq1
+  - wget http://download.zeromq.org/zeromq-4.0.4.tar.gz
+  - tar -xf zeromq-4.0.4.tar.gz
+  - cd zeromq-4.0.4
+  - ./configure
+  - make
+  - sudo make install
+  - sudo su -c "echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf"
+  - sudo ldconfig
+  - cd ..
+  - sudo mkdir -p /var/spool/marquise/
+  - sudo chown $USER /var/spool/marquise/
+
+install:
+  - 'cabal-$CABALVER update'
+  - 'cabal-$CABALVER sandbox init'
+  - 'git clone https://github.com/anchor/vaultaire-collector-common.git ../vaultaire-collector-common/'
+  - 'git clone https://github.com/anchor/vaultaire-common.git ../vaultaire-common/'
+  - 'git clone https://github.com/anchor/marquise.git ../marquise/'
+  - 'cabal-$CABALVER sandbox add-source ../vaultaire-collector-common/'
+  - 'cabal-$CABALVER sandbox add-source ../vaultaire-common/'
+  - 'cabal-$CABALVER sandbox add-source ../marquise/'
+  - 'cabal-$CABALVER install --only-dependencies --enable-tests --enable-benchmarks'
+
+script:
+  - 'cabal-$CABALVER test'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v0.1.1.0
+
+Strip whitespace from telemetry message types before storing them as
+sourcedict values.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,10 +37,6 @@ optionsParser = parseBroker
         <> showDefault
         <> help "Vault broker URI"
 
-
---                  optionsParser initExtraState             cleanup              collect
--- runCollector     Parser o      (CollectorOpts o -> m s)   Collector o s m ()   Collector o s m a
-
 main :: IO ()
 main = runCollector optionsParser initialiseExtraState cleanup collect
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -51,8 +51,6 @@ initialiseExtraState (_,broker) = do
 cleanup :: Collector String (Context,Socket a) IO ()
 cleanup = return ()
 
-
-
 makeCollectableThing :: TeleResp -> Either String (Address, SourceDict, TimeStamp, Word64)
 makeCollectableThing TeleResp{..} =
     let TeleMsg{..} = _msg
@@ -64,7 +62,6 @@ makeCollectableThing TeleResp{..} =
         sd <- makeSourceDict $ H.fromList $ map (bimap T.pack T.pack) sdPairs
         return (addr, sd, _timestamp, _payload)
 
-
 collect :: Receiver a => Collector String (Context,Socket a) IO ()
 collect = do
     (_, (_, sock)) <- get
@@ -73,7 +70,6 @@ collect = do
         case (fromWire datum :: Either SomeException TeleResp) of
           Right x -> either (liftIO . putStrLn) collectData (makeCollectableThing x)
           Left  e -> liftIO $ print e
-
 
 collectData :: (Address, SourceDict, TimeStamp, Word64) -> Collector o s IO ()
 collectData (addr, sd, ts, p) = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Trans
 import           Data.Bifunctor
 import qualified Data.ByteString.Char8              as BSC (pack)
 import qualified Data.HashMap.Strict                as H (fromList)
-import qualified Data.Text                          as T (pack)
+import qualified Data.Text                          as T (pack, strip)
 import           Data.Word                          (Word64)
 import           Network.URI
 import           Options.Applicative

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -59,7 +59,7 @@ makeCollectableThing TeleResp{..} =
                     , ("telemetry_msg_type", show _type) ]
         addr      = hashIdentifier $ BSC.pack $ concatMap snd sdPairs
     in do
-        sd <- makeSourceDict $ H.fromList $ map (bimap T.pack T.pack) sdPairs
+        sd <- makeSourceDict . H.fromList $ map (bimap T.pack (T.strip . T.pack)) sdPairs
         return (addr, sd, _timestamp, _payload)
 
 collect :: Receiver a => Collector String (Context,Socket a) IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,7 +18,7 @@ import qualified Data.Text                          as T (pack, strip)
 import           Data.Word                          (Word64)
 import           Network.URI
 import           Options.Applicative
-import           System.ZMQ4                        hiding (shutdown)
+import           System.ZMQ4
 
 import           Marquise.Client                    (hashIdentifier)
 import           Vaultaire.Types

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -59,8 +59,12 @@ makeCollectableThing TeleResp{..} =
                     , ("telemetry_msg_type", show _type) ]
         addr      = hashIdentifier $ BSC.pack $ concatMap snd sdPairs
     in do
-        sd <- makeSourceDict . H.fromList $ map (bimap T.pack (T.strip . T.pack)) sdPairs
+        sd <- makeSourceDict . H.fromList $ map mkTag sdPairs
         return (addr, sd, _timestamp, _payload)
+  where
+    -- Pack pairs into Texts, and strip off the whitespace padding from
+    -- the values.
+    mkTag = bimap T.pack (T.strip . T.pack)
 
 collect :: Receiver a => Collector String (Context,Socket a) IO ()
 collect = do

--- a/vaultaire-collector-vaultaire-telemetry.cabal
+++ b/vaultaire-collector-vaultaire-telemetry.cabal
@@ -1,5 +1,5 @@
 name:                vaultaire-collector-vaultaire-telemetry
-version:             0.1.0.0
+version:             0.1.1.0
 synopsis:            Vaultaire collector for Vaultaire telemetry
 description:         Vaultaire collector for Vaultaire telemetry
 homepage:            https://github.com/anchor/vaultaire-collector-vaultaire-telemetry


### PR DESCRIPTION
Telemetry messages have whitespace padding around the message type. It's not needed in sourcedicts.
