### PR TITLE
Add UOM to telemetry sourcedicts

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -56,6 +56,7 @@ makeCollectableThing TeleResp{..} =
     let TeleMsg{..} = _msg
         sdPairs   = [ ("agent_id",           show _aid)
                     , ("origin",             show _origin)
+                    , ("uom",                show $ msgTypeUOM $ _type)
                     , ("telemetry_msg_type", show _type) ]
         addr      = hashIdentifier $ BSC.pack $ concatMap snd sdPairs
     in do

--- a/vaultaire-collector-vaultaire-telemetry.cabal
+++ b/vaultaire-collector-vaultaire-telemetry.cabal
@@ -1,5 +1,5 @@
 name:                vaultaire-collector-vaultaire-telemetry
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Vaultaire collector for Vaultaire telemetry
 description:         Vaultaire collector for Vaultaire telemetry
 homepage:            https://github.com/anchor/vaultaire-collector-vaultaire-telemetry
@@ -24,7 +24,7 @@ executable vaultaire-collector-vaultaire-telemetry
                        bifunctors,
                        vaultaire-collector-common,
                        marquise,
-                       vaultaire-common,
+                       vaultaire-common >= 2.8.4,
                        bytestring,
                        text,
                        zeromq4-haskell,

--- a/vaultaire-collector-vaultaire-telemetry.cabal
+++ b/vaultaire-collector-vaultaire-telemetry.cabal
@@ -24,7 +24,7 @@ executable vaultaire-collector-vaultaire-telemetry
                        bifunctors,
                        vaultaire-collector-common,
                        marquise,
-                       vaultaire-common >= 2.8.5,
+                       vaultaire-common >= 2.9.0,
                        bytestring,
                        text,
                        zeromq4-haskell,

--- a/vaultaire-collector-vaultaire-telemetry.cabal
+++ b/vaultaire-collector-vaultaire-telemetry.cabal
@@ -24,7 +24,7 @@ executable vaultaire-collector-vaultaire-telemetry
                        bifunctors,
                        vaultaire-collector-common,
                        marquise,
-                       vaultaire-common >= 2.8.4,
+                       vaultaire-common >= 2.8.5,
                        bytestring,
                        text,
                        zeromq4-haskell,


### PR DESCRIPTION
Does what it says on the tin. This requires a PR #31 from vaultaire-common to be merged first: https://github.com/anchor/vaultaire-common/pull/31
